### PR TITLE
Fix console.warn color and add test

### DIFF
--- a/src/tinted-console.js
+++ b/src/tinted-console.js
@@ -18,7 +18,7 @@ const util = require('node:util'),
     'trace': 'gray',
     'debug': 'gray',
     'info': 'white',
-    'warn': 'orange',
+    'warn': 'yellow',
     'error': 'red',
   };
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -64,12 +64,15 @@ module.exports.assertFilesExist = function assertFilesExist(stdout, home, paths)
  * @param {function} done - Should be passed by Mocha test
  */
 module.exports.weAreOnline = function weAreOnline(done) {
-  const dns = require('dns');
-  dns.lookup('google.com', (err) => {
-    if (err && err.code === 'ENOTFOUND') {
+  const https = require('https');
+  https
+    .get('https://google.com', (res) => {
+      res.resume();
+      done();
+    })
+    .on('error', () => {
       console.log('No internet connection, skipping tests');
       this.skip();
-    }
-    done();
-  });
+      done();
+    });
 };

--- a/test/test_tinted_console.js
+++ b/test/test_tinted_console.js
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+const assert = require('assert');
+
+describe('tinted-console', () => {
+  it('allows console.warn without errors', () => {
+    require('../src/tinted-console');
+    assert.doesNotThrow(() => console.warn('ok'));
+  });
+});


### PR DESCRIPTION
## Summary
- fix `console.warn()` color mapping so the tinted console doesn't crash
- make online check skip tests if any network error occurs
- add a unit test for console.warn handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684973ccf2d8832da83b356b7b99c052